### PR TITLE
corect ecn filter when ecn flag is set

### DIFF
--- a/bpftools/p0f.py
+++ b/bpftools/p0f.py
@@ -3,7 +3,7 @@ import math
 
 ip = {
     'hl':   '(ip[0] & 0xf)',
-    'ecn':  '(ip[1] & 0x2)',
+    'ecn':  '(ip[1] & 0x2) | (tcp[tcpflags] & 0xc0)',
     'tl':   'ip[2:2]',
     'ipid': 'ip[4:2]',
     'df':   '(ip[6] & 0x40)',


### PR DESCRIPTION
p0f set ecn quirk in 2 scenarios: when tos_ecn is set, or tcp_ece&tcp_cwr flag is set.
Currently, bpftools only check if tos_ecn is set, which will generate the wrong filter